### PR TITLE
Fix sftp prefix in filezilla instructions

### DIFF
--- a/docs/connect-to-sftp-using-filezilla.md
+++ b/docs/connect-to-sftp-using-filezilla.md
@@ -28,7 +28,7 @@ Steps to install and operate FileZilla to connect to an SFTP endpoint.
 
 1. Enter the provided information into the FileZilla client:
 
-   - Hostname: Enter the hostname provided without `http://` or `https://` (Ex. `sftp.d3b.io`)
+   - Hostname: Enter the hostname provided with `sftp://` in front (Ex. `sftp://sftp.d3b.io`)
    - Username: Enter the provided username.
    - Password: Enter the provided password. (Note: This is case-sensitive.)
    - Port: Leave this blank. (FileZilla will use the default SFTP port, 21)


### PR DESCRIPTION
Fixing Filezilla connection instructions to include `sftp://` prefix when connecting. Filezilla assumes **FTP** protocol, and this needs to be specified for **SFTP**